### PR TITLE
Error when running from a path that contains spaces.

### DIFF
--- a/tasks/hamlbars.js
+++ b/tasks/hamlbars.js
@@ -29,11 +29,15 @@ module.exports = function(grunt) {
     });
   });
 
+  var wrapPath = function(path) {
+    return '"' + path + '"';
+  }
+
   var hamlbarize = function(filename) {
     var execSync = require('execSync');
     var target   = path.resolve(filename);
     var bin      = path.join(path.dirname(__dirname), 'bin', 'hamlbars');
-    var result   = execSync.exec(bin + ' ' + target);
+    var result   = execSync.exec(wrapPath(bin) + ' ' + wrapPath(target));
 
     if (result.code !== 0) {
       grunt.fail.warn(


### PR DESCRIPTION
Hi. Thanks for your work on this!

We ran into the following error when running the hamlbars task within a path structure that contains spaces:

```
Running "hamlbars:templates" (hamlbars) task
Warning: Error executing hamlbars on /Users/seejee/code/has spaces/lesson-player/app/templates/blank-view.hamlbars:
undefined
sh: /Users/seejee/code/has: No such file or directory
    Use --force to continue.
```

The attached commit should resolve the issue by wrapping the path with double quotes.
