### PR TITLE
Install bin/hamlbars to system

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Compile hamlbars to handlebars.",
   "version": "0.4.1",
   "homepage": "https://github.com/hrysd/grunt-hamlbars",
+  "bin": {
+    "hamlbars": "./bin/hamlbars"
+  },
   "author": {
     "name": "Hiroshi Yoshida",
     "email": "hrysd22@gmail.com"


### PR DESCRIPTION
Hi, thank you for creating useful grunt plugin.

I found it when I searching the way to compile Hamlbars template from command line.
I think it'd be nice if I can call `bin/hamlbars` script simply like `$ hamlbars template.hamlbars` for debugging purpose.

But I wonder I should send PR for `hamlbars` instead of `grunt-hamlbars` because CLI feature might be not a scope of grunt plugin.. what do you think? Do you have a plan to contribute your handy script to upstream hamlbars project?

FYI, the owner of Hamlbars project looks very positive to that contribution https://github.com/jamesotron/hamlbars/issues/66#issuecomment-76986742.
